### PR TITLE
Freely movable & resizable button cluster (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The page has inline guidance for each action type. Once configured, your buttons
 This extension is genuinely under active development and welcomes feedback from anyone who uses it.
 
 - **Bug reports and feature requests:** [open an issue](https://github.com/Megachile/inathelperJS/issues) — even half-formed thoughts ("this seems weird?", "what if it could do X?") are useful.
-- **Pull requests:** welcome. Run `npm test` before submitting (256 tests; see [TEST_README.md](TEST_README.md)).
+- **Pull requests:** welcome. Run `npm test` before submitting (309 tests; see [TEST_README.md](TEST_README.md)).
 
 ### Local development
 

--- a/content.js
+++ b/content.js
@@ -1664,19 +1664,25 @@ style.textContent += `
       padding: 2px 6px;
       user-select: none;
   }
-  #button-move-grip {
-      cursor: move;
-      opacity: 0.55;
+  /* Grip + gear are hidden at rest; hovering the cluster reveals them larger
+     and darker. Scale (not font-size) is used so revealing them doesn't reflow
+     the buttons. The gear also stays shown while its menu is open. */
+  #button-move-grip, #button-gear {
+      color: #777;
+      opacity: 0;
+      transition: opacity 0.12s ease, color 0.12s ease, transform 0.12s ease;
   }
-  #button-move-grip:hover { opacity: 1; }
-  /* Gear is always visible (discoverable) and toggles the sort/edit/set menu. */
-  #button-gear {
-      cursor: pointer;
-      opacity: 0.65;
-      transition: opacity 0.15s ease;
+  #button-move-grip { cursor: move; }
+  #button-gear { cursor: pointer; }
+  #custom-extension-wrapper:hover #button-move-grip,
+  #custom-extension-wrapper:hover #button-gear,
+  #custom-extension-wrapper.menu-open #button-gear {
+      opacity: 1;
+      color: #333;
+      transform: scale(1.25);
   }
-  #button-gear:hover,
-  #custom-extension-wrapper.menu-open #button-gear { opacity: 1; }
+  #button-move-grip:hover,
+  #button-gear:hover { color: #000; transform: scale(1.4); }
   #button-resize-grip {
       position: absolute;
       right: -7px;

--- a/content.js
+++ b/content.js
@@ -752,12 +752,17 @@ function getClusterOverhang() {
     };
 }
 
+// Use the documentElement client box, not window.inner*, so the cluster (and
+// its right-/bottom-sticking grips) stays clear of the scrollbar gutter.
+function viewportW() { return document.documentElement.clientWidth || window.innerWidth; }
+function viewportH() { return document.documentElement.clientHeight || window.innerHeight; }
+
 function clampButtonToViewport(left, top) {
     const o = getClusterOverhang();
     let visLeft = left - o.overLeft;
     let visTop = top - o.overTop;
-    visLeft = Math.max(0, Math.min(visLeft, Math.max(0, window.innerWidth - o.width)));
-    visTop = Math.max(0, Math.min(visTop, Math.max(0, window.innerHeight - o.height)));
+    visLeft = Math.max(0, Math.min(visLeft, Math.max(0, viewportW() - o.width)));
+    visTop = Math.max(0, Math.min(visTop, Math.max(0, viewportH() - o.height)));
     return { left: visLeft + o.overLeft, top: visTop + o.overTop };
 }
 
@@ -768,12 +773,12 @@ function alignSortContainerToCluster() {
     const sortC = document.getElementById('sort-buttons-container');
     if (!sortC) return;
     const r = buttonDiv.getBoundingClientRect();
-    if ((r.left + r.width / 2) < window.innerWidth / 2) {
+    if ((r.left + r.width / 2) < viewportW() / 2) {
         sortC.style.left = '0'; sortC.style.right = 'auto';
     } else {
         sortC.style.right = '0'; sortC.style.left = 'auto';
     }
-    if ((r.top + r.height / 2) < window.innerHeight / 2) {
+    if ((r.top + r.height / 2) < viewportH() / 2) {
         sortC.style.top = '100%'; sortC.style.bottom = 'auto';   // controls below the buttons
     } else {
         sortC.style.bottom = '100%'; sortC.style.top = 'auto';   // controls above the buttons
@@ -1651,11 +1656,12 @@ style.textContent += `
   #button-drag-handle {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      font-size: 13px;
+      justify-content: flex-end;
+      gap: 10px;
+      font-size: 14px;
       line-height: 1;
       color: #888;
-      padding: 2px 4px;
+      padding: 2px 6px;
       user-select: none;
   }
   #button-move-grip {
@@ -1663,17 +1669,11 @@ style.textContent += `
       opacity: 0.55;
   }
   #button-move-grip:hover { opacity: 1; }
-  /* Gear stays hidden until the cluster is hovered, then toggles the menu. */
+  /* Gear is always visible (discoverable) and toggles the sort/edit/set menu. */
   #button-gear {
       cursor: pointer;
-      opacity: 0;
-      pointer-events: none;
+      opacity: 0.65;
       transition: opacity 0.15s ease;
-  }
-  #custom-extension-wrapper:hover #button-gear,
-  #custom-extension-wrapper.menu-open #button-gear {
-      opacity: 0.55;
-      pointer-events: auto;
   }
   #button-gear:hover,
   #custom-extension-wrapper.menu-open #button-gear { opacity: 1; }

--- a/content.js
+++ b/content.js
@@ -174,7 +174,8 @@ function createShortcutList() {
     list.innerHTML = `
         <li>Shift + B: Toggle button visibility</li>
         <li>Shift + V: Toggle bulk action box</li>
-        <li>Alt + N: Cycle button position</li>
+        <li>Alt + N: Cycle button position (resets free move/resize)</li>
+        <li>Drag the ☰ handle to move buttons freely; drag the corner grip to resize</li>
         <li>Ctrl + Shift + R: Toggle refresh</li>
         <li>Alt + H: Toggle this shortcut list</li>
         <li>Alt + S: Cycle through button sets</li>
@@ -380,6 +381,8 @@ function toggleButtonVisibility() {
 }
 
 function cycleButtonPosition() {
+    // Alt+N doubles as the "snap back to a corner" reset for free drag/resize.
+    if (typeof resetFreeButtonLayout === 'function') resetFreeButtonLayout();
     currentPositionIndex = (currentPositionIndex + 1) % positions.length;
     buttonPosition = positions[currentPositionIndex];
     updatePositions();
@@ -451,6 +454,10 @@ function updatePositions() {
                 idDisplay.style.left = '10px';
             }
             break;
+    }
+    // A saved free position overrides the corner preset (e.g. after a re-render).
+    if (typeof freeButtonPosition !== 'undefined' && freeButtonPosition) {
+        applyFreeButtonPosition();
     }
     updateBulkButtonPosition();
 }
@@ -668,6 +675,142 @@ buttonContainer.id = 'custom-extension-container';
 
 buttonDiv.appendChild(buttonContainer);
 document.body.appendChild(buttonDiv);
+
+// --- Free positioning & resizing (issue #54) ---------------------------------
+// Beyond the four corner presets (Alt+N), the whole button cluster can be
+// dragged anywhere via a grip handle and resized via a corner grip. The chosen
+// position/size persist to storage.local and take precedence over the corner
+// preset. Alt+N clears them again, acting as a "snap back to a corner" reset.
+let freeButtonPosition = null; // {left, top} in px, or null
+let freeButtonSize = null;     // {width, height} in px, or null
+
+// Drag handle (slim grip bar at the top of the cluster).
+const dragHandle = document.createElement('div');
+dragHandle.id = 'button-drag-handle';
+dragHandle.title = 'Drag to move buttons — Alt+N snaps back to a corner';
+dragHandle.textContent = '☰'; // trigram / grip glyph
+buttonDiv.insertBefore(dragHandle, buttonContainer);
+
+// Resize grip (corner handle on the button container). A custom grip is used
+// instead of CSS `resize` so the container can keep `overflow: visible` and not
+// clip button tooltips.
+const resizeGrip = document.createElement('div');
+resizeGrip.id = 'button-resize-grip';
+resizeGrip.title = 'Drag to resize the button area';
+buttonDiv.appendChild(resizeGrip);
+
+function clampButtonToViewport(left, top, width, height) {
+    const maxLeft = Math.max(0, window.innerWidth - width);
+    const maxTop = Math.max(0, window.innerHeight - height);
+    return {
+        left: Math.max(0, Math.min(left, maxLeft)),
+        top: Math.max(0, Math.min(top, maxTop))
+    };
+}
+
+function applyFreeButtonPosition() {
+    if (!freeButtonPosition) return;
+    const rect = buttonDiv.getBoundingClientRect();
+    const pos = clampButtonToViewport(freeButtonPosition.left, freeButtonPosition.top, rect.width, rect.height);
+    buttonDiv.style.top = pos.top + 'px';
+    buttonDiv.style.left = pos.left + 'px';
+    buttonDiv.style.right = 'auto';
+    buttonDiv.style.bottom = 'auto';
+}
+
+function applyFreeButtonSize() {
+    if (!freeButtonSize) return;
+    buttonContainer.style.maxWidth = 'none';
+    buttonContainer.style.width = freeButtonSize.width + 'px';
+    buttonContainer.style.height = freeButtonSize.height + 'px';
+}
+
+function resetFreeButtonLayout() {
+    freeButtonPosition = null;
+    freeButtonSize = null;
+    buttonContainer.style.maxWidth = '';
+    buttonContainer.style.width = '';
+    buttonContainer.style.height = '';
+    browserAPI.storage.local.remove(['buttonFreePosition', 'buttonFreeSize']);
+}
+
+// Drag-to-move
+let isButtonDragging = false, clusterDragOffsetX = 0, clusterDragOffsetY = 0;
+function onButtonDragMove(e) {
+    if (!isButtonDragging) return;
+    const rect = buttonDiv.getBoundingClientRect();
+    const pos = clampButtonToViewport(e.clientX - clusterDragOffsetX, e.clientY - clusterDragOffsetY, rect.width, rect.height);
+    buttonDiv.style.top = pos.top + 'px';
+    buttonDiv.style.left = pos.left + 'px';
+    buttonDiv.style.right = 'auto';
+    buttonDiv.style.bottom = 'auto';
+}
+function onButtonDragEnd() {
+    if (!isButtonDragging) return;
+    isButtonDragging = false;
+    document.removeEventListener('mousemove', onButtonDragMove);
+    document.removeEventListener('mouseup', onButtonDragEnd);
+    const rect = buttonDiv.getBoundingClientRect();
+    freeButtonPosition = { left: rect.left, top: rect.top };
+    browserAPI.storage.local.set({ buttonFreePosition: freeButtonPosition });
+}
+dragHandle.addEventListener('mousedown', function(e) {
+    isButtonDragging = true;
+    const rect = buttonDiv.getBoundingClientRect();
+    clusterDragOffsetX = e.clientX - rect.left;
+    clusterDragOffsetY = e.clientY - rect.top;
+    e.preventDefault();
+    document.addEventListener('mousemove', onButtonDragMove);
+    document.addEventListener('mouseup', onButtonDragEnd);
+});
+
+// Drag-to-resize
+let isButtonResizing = false, resizeStartX = 0, resizeStartY = 0, resizeStartW = 0, resizeStartH = 0;
+function onButtonResizeMove(e) {
+    if (!isButtonResizing) return;
+    const w = Math.max(80, resizeStartW + (e.clientX - resizeStartX));
+    const h = Math.max(28, resizeStartH + (e.clientY - resizeStartY));
+    buttonContainer.style.width = w + 'px';
+    buttonContainer.style.height = h + 'px';
+}
+function onButtonResizeEnd() {
+    if (!isButtonResizing) return;
+    isButtonResizing = false;
+    document.removeEventListener('mousemove', onButtonResizeMove);
+    document.removeEventListener('mouseup', onButtonResizeEnd);
+    freeButtonSize = { width: buttonContainer.offsetWidth, height: buttonContainer.offsetHeight };
+    browserAPI.storage.local.set({ buttonFreeSize: freeButtonSize });
+}
+resizeGrip.addEventListener('mousedown', function(e) {
+    isButtonResizing = true;
+    resizeStartX = e.clientX;
+    resizeStartY = e.clientY;
+    resizeStartW = buttonContainer.offsetWidth;
+    resizeStartH = buttonContainer.offsetHeight;
+    buttonContainer.style.maxWidth = 'none';
+    e.preventDefault();
+    e.stopPropagation();
+    document.addEventListener('mousemove', onButtonResizeMove);
+    document.addEventListener('mouseup', onButtonResizeEnd);
+});
+
+// Keep the cluster on-screen if the viewport shrinks.
+window.addEventListener('resize', function() {
+    if (freeButtonPosition) applyFreeButtonPosition();
+});
+
+// Restore any saved free layout.
+browserAPI.storage.local.get(['buttonFreePosition', 'buttonFreeSize'], function(data) {
+    if (data.buttonFreeSize) {
+        freeButtonSize = data.buttonFreeSize;
+        applyFreeButtonSize();
+    }
+    if (data.buttonFreePosition) {
+        freeButtonPosition = data.buttonFreePosition;
+        applyFreeButtonPosition();
+    }
+});
+// -----------------------------------------------------------------------------
 
 
 
@@ -1424,6 +1567,29 @@ style.textContent += `
       gap: 5px;
       max-width: var(--button-container-max-width, 600px);
   }
+  #button-drag-handle {
+      cursor: move;
+      font-size: 13px;
+      line-height: 1;
+      color: #888;
+      text-align: center;
+      padding: 2px 4px;
+      user-select: none;
+      opacity: 0.55;
+  }
+  #button-drag-handle:hover { opacity: 1; }
+  #button-resize-grip {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 14px;
+      height: 14px;
+      cursor: nwse-resize;
+      opacity: 0.55;
+      z-index: 10003;
+      background: linear-gradient(135deg, transparent 0 45%, #888 45% 55%, transparent 55% 70%, #888 70% 80%, transparent 80%);
+  }
+  #button-resize-grip:hover { opacity: 1; }
     #custom-extension-container.dragging {
     height: var(--original-height);
     width: var(--original-width);

--- a/content.js
+++ b/content.js
@@ -455,7 +455,8 @@ function updatePositions() {
             }
             break;
     }
-    // A saved free position overrides the corner preset (e.g. after a re-render).
+    // A saved free position overrides the corner preset (e.g. after a re-render),
+    // including re-snapping the sort/edit/set controls to the nearest side/edge.
     if (typeof freeButtonPosition !== 'undefined' && freeButtonPosition) {
         applyFreeButtonPosition();
     }
@@ -699,23 +700,66 @@ resizeGrip.id = 'button-resize-grip';
 resizeGrip.title = 'Drag to resize the button area';
 buttonDiv.appendChild(resizeGrip);
 
-function clampButtonToViewport(left, top, width, height) {
-    const maxLeft = Math.max(0, window.innerWidth - width);
-    const maxTop = Math.max(0, window.innerHeight - height);
+// The sort/edit/set-picker controls (#sort-buttons-container) are absolutely
+// positioned relative to buttonDiv and overhang it (above or below, left- or
+// right-aligned). Measure how far the visible cluster extends past buttonDiv so
+// the clamp keeps the *whole* cluster on-screen, not just the buttons.
+function getClusterOverhang() {
+    const divRect = buttonDiv.getBoundingClientRect();
+    let left = divRect.left, top = divRect.top, right = divRect.right, bottom = divRect.bottom;
+    const sortC = document.getElementById('sort-buttons-container');
+    if (sortC && sortC.offsetParent !== null) {
+        const r = sortC.getBoundingClientRect();
+        left = Math.min(left, r.left);
+        top = Math.min(top, r.top);
+        right = Math.max(right, r.right);
+        bottom = Math.max(bottom, r.bottom);
+    }
     return {
-        left: Math.max(0, Math.min(left, maxLeft)),
-        top: Math.max(0, Math.min(top, maxTop))
+        overLeft: divRect.left - left,   // how far the cluster sticks out to the left of buttonDiv
+        overTop: divRect.top - top,      // ...above buttonDiv
+        width: right - left,
+        height: bottom - top
     };
+}
+
+function clampButtonToViewport(left, top) {
+    const o = getClusterOverhang();
+    let visLeft = left - o.overLeft;
+    let visTop = top - o.overTop;
+    visLeft = Math.max(0, Math.min(visLeft, Math.max(0, window.innerWidth - o.width)));
+    visTop = Math.max(0, Math.min(visTop, Math.max(0, window.innerHeight - o.height)));
+    return { left: visLeft + o.overLeft, top: visTop + o.overTop };
+}
+
+// Snap the sort/edit/set controls to the side and vertical edge nearest the
+// cluster, instead of leaving them hard-anchored to the top-right. Mirrors the
+// corner-preset behaviour so they don't clip off-screen when moved.
+function alignSortContainerToCluster() {
+    const sortC = document.getElementById('sort-buttons-container');
+    if (!sortC) return;
+    const r = buttonDiv.getBoundingClientRect();
+    if ((r.left + r.width / 2) < window.innerWidth / 2) {
+        sortC.style.left = '0'; sortC.style.right = 'auto';
+    } else {
+        sortC.style.right = '0'; sortC.style.left = 'auto';
+    }
+    if ((r.top + r.height / 2) < window.innerHeight / 2) {
+        sortC.style.top = '100%'; sortC.style.bottom = 'auto';   // controls below the buttons
+    } else {
+        sortC.style.bottom = '100%'; sortC.style.top = 'auto';   // controls above the buttons
+    }
 }
 
 function applyFreeButtonPosition() {
     if (!freeButtonPosition) return;
-    const rect = buttonDiv.getBoundingClientRect();
-    const pos = clampButtonToViewport(freeButtonPosition.left, freeButtonPosition.top, rect.width, rect.height);
+    alignSortContainerToCluster();
+    const pos = clampButtonToViewport(freeButtonPosition.left, freeButtonPosition.top);
     buttonDiv.style.top = pos.top + 'px';
     buttonDiv.style.left = pos.left + 'px';
     buttonDiv.style.right = 'auto';
     buttonDiv.style.bottom = 'auto';
+    alignSortContainerToCluster();
 }
 
 function applyFreeButtonSize() {
@@ -738,12 +782,12 @@ function resetFreeButtonLayout() {
 let isButtonDragging = false, clusterDragOffsetX = 0, clusterDragOffsetY = 0;
 function onButtonDragMove(e) {
     if (!isButtonDragging) return;
-    const rect = buttonDiv.getBoundingClientRect();
-    const pos = clampButtonToViewport(e.clientX - clusterDragOffsetX, e.clientY - clusterDragOffsetY, rect.width, rect.height);
+    const pos = clampButtonToViewport(e.clientX - clusterDragOffsetX, e.clientY - clusterDragOffsetY);
     buttonDiv.style.top = pos.top + 'px';
     buttonDiv.style.left = pos.left + 'px';
     buttonDiv.style.right = 'auto';
     buttonDiv.style.bottom = 'auto';
+    alignSortContainerToCluster();
 }
 function onButtonDragEnd() {
     if (!isButtonDragging) return;

--- a/content.js
+++ b/content.js
@@ -176,7 +176,7 @@ function createShortcutList() {
         <li>Shift + V: Toggle bulk action box</li>
         <li>Alt + N: Cycle button position (resets free move/resize)</li>
         <li>Drag the ☰ handle to move buttons freely; drag the corner grip to resize</li>
-        <li>Sort / Edit / Set-picker controls appear when you hover the buttons</li>
+        <li>Hover the buttons and click the ⚙ gear for Sort / Edit / Set-picker controls</li>
         <li>Ctrl + Shift + R: Toggle refresh</li>
         <li>Alt + H: Toggle this shortcut list</li>
         <li>Alt + S: Cycle through button sets</li>
@@ -687,12 +687,37 @@ document.body.appendChild(buttonDiv);
 let freeButtonPosition = null; // {left, top} in px, or null
 let freeButtonSize = null;     // {width, height} in px, or null
 
-// Drag handle (slim grip bar at the top of the cluster).
+// Slim control strip at the top of the cluster: a move grip on the left and a
+// gear on the right. The gear reveals on hover and toggles the sort/edit/set
+// controls (#sort-buttons-container) so those rarely-used buttons don't take up
+// permanent space.
 const dragHandle = document.createElement('div');
 dragHandle.id = 'button-drag-handle';
-dragHandle.title = 'Drag to move buttons — Alt+N snaps back to a corner';
-dragHandle.textContent = '☰'; // trigram / grip glyph
+
+const moveGrip = document.createElement('span');
+moveGrip.id = 'button-move-grip';
+moveGrip.textContent = '☰'; // trigram / grip glyph
+moveGrip.title = 'Drag to move buttons — Alt+N snaps back to a corner';
+
+const gearButton = document.createElement('span');
+gearButton.id = 'button-gear';
+gearButton.textContent = '⚙';
+gearButton.title = 'Sort / Edit layout / Switch set';
+
+dragHandle.appendChild(moveGrip);
+dragHandle.appendChild(gearButton);
 buttonDiv.insertBefore(dragHandle, buttonContainer);
+
+// Gear toggles the menu; click-away closes it.
+gearButton.addEventListener('click', function(e) {
+    e.stopPropagation();
+    buttonDiv.classList.toggle('menu-open');
+});
+document.addEventListener('click', function(e) {
+    if (buttonDiv.classList.contains('menu-open') && !buttonDiv.contains(e.target)) {
+        buttonDiv.classList.remove('menu-open');
+    }
+});
 
 // Resize grip (corner handle on the button container). A custom grip is used
 // instead of CSS `resize` so the container can keep `overflow: visible` and not
@@ -770,7 +795,10 @@ function applyFreeButtonSize() {
     if (!freeButtonSize) return;
     buttonContainer.style.maxWidth = 'none';
     buttonContainer.style.width = freeButtonSize.width + 'px';
-    buttonContainer.style.height = freeButtonSize.height + 'px';
+    // min-height (not a hard height) so taller content always stays inside the
+    // box — otherwise overflow spills out and the toolbar/grip, which anchor to
+    // the box edge, end up in the middle of the buttons.
+    buttonContainer.style.minHeight = freeButtonSize.height + 'px';
 }
 
 function resetFreeButtonLayout() {
@@ -778,7 +806,7 @@ function resetFreeButtonLayout() {
     freeButtonSize = null;
     buttonContainer.style.maxWidth = '';
     buttonContainer.style.width = '';
-    buttonContainer.style.height = '';
+    buttonContainer.style.minHeight = '';
     browserAPI.storage.local.remove(['buttonFreePosition', 'buttonFreeSize']);
 }
 
@@ -802,7 +830,8 @@ function onButtonDragEnd() {
     freeButtonPosition = { left: rect.left, top: rect.top };
     browserAPI.storage.local.set({ buttonFreePosition: freeButtonPosition });
 }
-dragHandle.addEventListener('mousedown', function(e) {
+// Only the move grip starts a drag (so clicking the gear doesn't move things).
+moveGrip.addEventListener('mousedown', function(e) {
     isButtonDragging = true;
     const rect = buttonDiv.getBoundingClientRect();
     clusterDragOffsetX = e.clientX - rect.left;
@@ -819,14 +848,17 @@ function onButtonResizeMove(e) {
     const w = Math.max(80, resizeStartW + (e.clientX - resizeStartX));
     const h = Math.max(28, resizeStartH + (e.clientY - resizeStartY));
     buttonContainer.style.width = w + 'px';
-    buttonContainer.style.height = h + 'px';
+    buttonContainer.style.minHeight = h + 'px';
 }
 function onButtonResizeEnd() {
     if (!isButtonResizing) return;
     isButtonResizing = false;
     document.removeEventListener('mousemove', onButtonResizeMove);
     document.removeEventListener('mouseup', onButtonResizeEnd);
-    freeButtonSize = { width: buttonContainer.offsetWidth, height: buttonContainer.offsetHeight };
+    freeButtonSize = {
+        width: buttonContainer.offsetWidth,
+        height: parseInt(buttonContainer.style.minHeight, 10) || buttonContainer.offsetHeight
+    };
     browserAPI.storage.local.set({ buttonFreeSize: freeButtonSize });
 }
 resizeGrip.addEventListener('mousedown', function(e) {
@@ -1612,20 +1644,39 @@ style.textContent += `
       display: flex;
       flex-direction: var(--button-flex-direction, row);
       flex-wrap: wrap;
+      align-content: flex-start;
       gap: 5px;
       max-width: var(--button-container-max-width, 600px);
   }
   #button-drag-handle {
-      cursor: move;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       font-size: 13px;
       line-height: 1;
       color: #888;
-      text-align: center;
       padding: 2px 4px;
       user-select: none;
+  }
+  #button-move-grip {
+      cursor: move;
       opacity: 0.55;
   }
-  #button-drag-handle:hover { opacity: 1; }
+  #button-move-grip:hover { opacity: 1; }
+  /* Gear stays hidden until the cluster is hovered, then toggles the menu. */
+  #button-gear {
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease;
+  }
+  #custom-extension-wrapper:hover #button-gear,
+  #custom-extension-wrapper.menu-open #button-gear {
+      opacity: 0.55;
+      pointer-events: auto;
+  }
+  #button-gear:hover,
+  #custom-extension-wrapper.menu-open #button-gear { opacity: 1; }
   #button-resize-grip {
       position: absolute;
       right: -7px;
@@ -1758,8 +1809,9 @@ style.textContent += `
         pointer-events: none;
         transition: opacity 0.15s ease;
     }
-    /* Reveal the rarely-used sort/edit/set controls only on hover (issue #54). */
-    #custom-extension-wrapper:hover #sort-buttons-container {
+    /* Reveal the rarely-used sort/edit/set controls only when the gear menu is
+       open (issue #54). The gear itself is hover-revealed. */
+    #custom-extension-wrapper.menu-open #sort-buttons-container {
         opacity: 1;
         pointer-events: auto;
     }

--- a/content.js
+++ b/content.js
@@ -176,6 +176,7 @@ function createShortcutList() {
         <li>Shift + V: Toggle bulk action box</li>
         <li>Alt + N: Cycle button position (resets free move/resize)</li>
         <li>Drag the ☰ handle to move buttons freely; drag the corner grip to resize</li>
+        <li>Sort / Edit / Set-picker controls appear when you hover the buttons</li>
         <li>Ctrl + Shift + R: Toggle refresh</li>
         <li>Alt + H: Toggle this shortcut list</li>
         <li>Alt + S: Cycle through button sets</li>
@@ -668,6 +669,7 @@ function animateButton(button) {
 
 // Create buttons and add them to the page
 let buttonDiv = document.createElement('div');
+buttonDiv.id = 'custom-extension-wrapper';
 buttonDiv.style.position = 'fixed';
 buttonDiv.style.zIndex = '10000';
 
@@ -707,14 +709,16 @@ buttonDiv.appendChild(resizeGrip);
 function getClusterOverhang() {
     const divRect = buttonDiv.getBoundingClientRect();
     let left = divRect.left, top = divRect.top, right = divRect.right, bottom = divRect.bottom;
-    const sortC = document.getElementById('sort-buttons-container');
-    if (sortC && sortC.offsetParent !== null) {
-        const r = sortC.getBoundingClientRect();
-        left = Math.min(left, r.left);
-        top = Math.min(top, r.top);
-        right = Math.max(right, r.right);
-        bottom = Math.max(bottom, r.bottom);
-    }
+    const overhangers = [document.getElementById('sort-buttons-container'), resizeGrip];
+    overhangers.forEach(el => {
+        if (el && el.offsetParent !== null) {
+            const r = el.getBoundingClientRect();
+            left = Math.min(left, r.left);
+            top = Math.min(top, r.top);
+            right = Math.max(right, r.right);
+            bottom = Math.max(bottom, r.bottom);
+        }
+    });
     return {
         overLeft: divRect.left - left,   // how far the cluster sticks out to the left of buttonDiv
         overTop: divRect.top - top,      // ...above buttonDiv
@@ -1624,16 +1628,22 @@ style.textContent += `
   #button-drag-handle:hover { opacity: 1; }
   #button-resize-grip {
       position: absolute;
-      right: 0;
-      bottom: 0;
-      width: 14px;
-      height: 14px;
+      right: -7px;
+      bottom: -7px;
+      width: 16px;
+      height: 16px;
       cursor: nwse-resize;
-      opacity: 0.55;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease;
       z-index: 10003;
       background: linear-gradient(135deg, transparent 0 45%, #888 45% 55%, transparent 55% 70%, #888 70% 80%, transparent 80%);
   }
-  #button-resize-grip:hover { opacity: 1; }
+  #custom-extension-wrapper:hover #button-resize-grip {
+      opacity: 0.55;
+      pointer-events: auto;
+  }
+  #button-resize-grip:hover { opacity: 1 !important; }
     #custom-extension-container.dragging {
     height: var(--original-height);
     width: var(--original-width);
@@ -1744,6 +1754,14 @@ style.textContent += `
         top: -30px;
         right: 0;
         z-index: 10002;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.15s ease;
+    }
+    /* Reveal the rarely-used sort/edit/set controls only on hover (issue #54). */
+    #custom-extension-wrapper:hover #sort-buttons-container {
+        opacity: 1;
+        pointer-events: auto;
     }
     #sort-button {
         background-color: rgba(0, 0, 0, 0.1);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "iNaturalist Metadata Tool",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Configurable buttons and shortcuts for iNaturalist: bulk annotations, tags, fields, projects, and a URL filter builder.",
   "author": "Adam Kranz",
   "homepage_url": "https://github.com/Megachile/inathelperJS",

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+const contentSource = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+// Issue #54: forum user konrad_k asked for the button cluster to be "freely
+// resizable and movable", beyond the four corner presets cycled with Alt+N.
+// Implementation adds a drag handle (move anywhere) and a corner grip (resize),
+// persists the chosen layout to storage.local, re-clamps to the viewport, and
+// lets Alt+N reset back to a corner preset.
+describe('Free button positioning & resizing (issue #54)', () => {
+    test('a drag handle element is created and inserted before the container', () => {
+        expect(contentSource).toMatch(/id = 'button-drag-handle'/);
+        expect(contentSource).toMatch(/buttonDiv\.insertBefore\(dragHandle, buttonContainer\)/);
+    });
+
+    test('a custom resize grip is created (not CSS resize, to avoid clipping tooltips)', () => {
+        expect(contentSource).toMatch(/id = 'button-resize-grip'/);
+        expect(contentSource).toMatch(/buttonDiv\.appendChild\(resizeGrip\)/);
+    });
+
+    test('drag updates left/top and clears the corner anchors', () => {
+        expect(contentSource).toMatch(/function onButtonDragMove/);
+        expect(contentSource).toMatch(/buttonDiv\.style\.right = 'auto'/);
+        expect(contentSource).toMatch(/buttonDiv\.style\.bottom = 'auto'/);
+    });
+
+    test('drag and resize persist their results to storage.local', () => {
+        expect(contentSource).toMatch(/storage\.local\.set\(\{ buttonFreePosition: freeButtonPosition \}\)/);
+        expect(contentSource).toMatch(/storage\.local\.set\(\{ buttonFreeSize: freeButtonSize \}\)/);
+    });
+
+    test('saved free layout is restored on load', () => {
+        expect(contentSource).toMatch(/storage\.local\.get\(\['buttonFreePosition', 'buttonFreeSize'\]/);
+        expect(contentSource).toMatch(/applyFreeButtonPosition\(\)/);
+        expect(contentSource).toMatch(/applyFreeButtonSize\(\)/);
+    });
+
+    test('position is clamped into the viewport (on apply and on window resize)', () => {
+        expect(contentSource).toMatch(/function clampButtonToViewport/);
+        expect(contentSource).toMatch(/window\.innerWidth - width/);
+        expect(contentSource).toMatch(/window\.addEventListener\('resize', function\(\) \{\s*if \(freeButtonPosition\) applyFreeButtonPosition\(\);/);
+    });
+
+    test('resize overrides the max-width cap so the cluster can grow', () => {
+        expect(contentSource).toMatch(/buttonContainer\.style\.maxWidth = 'none'/);
+    });
+
+    test('Alt+N (cycleButtonPosition) resets the free layout as an escape hatch', () => {
+        expect(contentSource).toMatch(/if \(typeof resetFreeButtonLayout === 'function'\) resetFreeButtonLayout\(\)/);
+        expect(contentSource).toMatch(/function resetFreeButtonLayout/);
+        expect(contentSource).toMatch(/storage\.local\.remove\(\['buttonFreePosition', 'buttonFreeSize'\]\)/);
+    });
+
+    test('updatePositions re-applies a saved free position over the corner preset', () => {
+        expect(contentSource).toMatch(/if \(typeof freeButtonPosition !== 'undefined' && freeButtonPosition\) \{\s*applyFreeButtonPosition\(\);/);
+    });
+});

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -84,11 +84,37 @@ describe('Free button positioning & resizing (issue #54)', () => {
         expect(contentSource).toMatch(/buttonDiv\.id = 'custom-extension-wrapper'/);
     });
 
-    test('utility controls are hidden by default and revealed on hover (#54 polish)', () => {
+    test('utility controls are hidden by default and revealed behind the gear (#54 polish)', () => {
         // The sort/edit/set controls take up permanent space for rarely-used
-        // actions, so they fade in only when the cluster is hovered.
+        // actions, so they hide behind a gear and only show when the menu is open.
         expect(contentSource).toMatch(/#sort-buttons-container \{[\s\S]*?opacity: 0;[\s\S]*?pointer-events: none;[\s\S]*?\}/);
-        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #sort-buttons-container \{[\s\S]*?opacity: 1;[\s\S]*?pointer-events: auto;/);
+        expect(contentSource).toMatch(/#custom-extension-wrapper\.menu-open #sort-buttons-container \{[\s\S]*?opacity: 1;[\s\S]*?pointer-events: auto;/);
+    });
+
+    test('a gear button is added, hover-revealed, and toggles the menu', () => {
+        expect(contentSource).toMatch(/id = 'button-gear'/);
+        // Gear is hidden until hover; visible on wrapper hover or when menu is open.
+        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #button-gear,\s*#custom-extension-wrapper\.menu-open #button-gear \{/);
+        expect(contentSource).toMatch(/gearButton\.addEventListener\('click', function\(e\) \{[\s\S]*?buttonDiv\.classList\.toggle\('menu-open'\)/);
+    });
+
+    test('click-away closes the gear menu', () => {
+        expect(contentSource).toMatch(/document\.addEventListener\('click', function\(e\) \{[\s\S]*?!buttonDiv\.contains\(e\.target\)[\s\S]*?classList\.remove\('menu-open'\)/);
+    });
+
+    test('only the move grip starts a drag (gear clicks do not move the cluster)', () => {
+        expect(contentSource).toMatch(/id = 'button-move-grip'/);
+        expect(contentSource).toMatch(/moveGrip\.addEventListener\('mousedown'/);
+    });
+
+    test('resize uses min-height (not a hard height) so content never spills out', () => {
+        // Fixes the "toolbar lands in the middle of the buttons" bug: a hard
+        // height with overflow:visible let buttons spill past the box edge.
+        expect(contentSource).toMatch(/buttonContainer\.style\.minHeight = h \+ 'px'/);
+        expect(contentSource).toMatch(/buttonContainer\.style\.minHeight = freeButtonSize\.height \+ 'px'/);
+        expect(contentSource).not.toMatch(/buttonContainer\.style\.height = h \+ 'px'/);
+        // align-content keeps wrapped rows top-packed when min-height adds slack.
+        expect(contentSource).toMatch(/align-content: flex-start/);
     });
 
     test('resize grip is offset off the corner and also hover-revealed', () => {

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -79,4 +79,24 @@ describe('Free button positioning & resizing (issue #54)', () => {
     test('updatePositions re-applies a saved free position over the corner preset', () => {
         expect(contentSource).toMatch(/if \(typeof freeButtonPosition !== 'undefined' && freeButtonPosition\) \{\s*applyFreeButtonPosition\(\);/);
     });
+
+    test('the wrapper has an id to anchor hover-reveal CSS', () => {
+        expect(contentSource).toMatch(/buttonDiv\.id = 'custom-extension-wrapper'/);
+    });
+
+    test('utility controls are hidden by default and revealed on hover (#54 polish)', () => {
+        // The sort/edit/set controls take up permanent space for rarely-used
+        // actions, so they fade in only when the cluster is hovered.
+        expect(contentSource).toMatch(/#sort-buttons-container \{[\s\S]*?opacity: 0;[\s\S]*?pointer-events: none;[\s\S]*?\}/);
+        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #sort-buttons-container \{[\s\S]*?opacity: 1;[\s\S]*?pointer-events: auto;/);
+    });
+
+    test('resize grip is offset off the corner and also hover-revealed', () => {
+        expect(contentSource).toMatch(/#button-resize-grip \{[\s\S]*?right: -7px;[\s\S]*?bottom: -7px;/);
+        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #button-resize-grip \{[\s\S]*?opacity: 0\.55;[\s\S]*?pointer-events: auto;/);
+    });
+
+    test('overhang measurement includes the resize grip so the offset cannot clip off-screen', () => {
+        expect(contentSource).toMatch(/const overhangers = \[document\.getElementById\('sort-buttons-container'\), resizeGrip\]/);
+    });
 });

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -38,8 +38,32 @@ describe('Free button positioning & resizing (issue #54)', () => {
 
     test('position is clamped into the viewport (on apply and on window resize)', () => {
         expect(contentSource).toMatch(/function clampButtonToViewport/);
-        expect(contentSource).toMatch(/window\.innerWidth - width/);
+        expect(contentSource).toMatch(/window\.innerWidth - o\.width/);
         expect(contentSource).toMatch(/window\.addEventListener\('resize', function\(\) \{\s*if \(freeButtonPosition\) applyFreeButtonPosition\(\);/);
+    });
+
+    test('clamp accounts for the overhanging sort/edit/set controls (no top-edge clipping)', () => {
+        // #54 follow-up: the sort-buttons-container is absolutely positioned and
+        // overhangs buttonDiv, so clamping on buttonDiv alone let it clip past
+        // the top edge. The clamp now measures the full cluster extent.
+        expect(contentSource).toMatch(/function getClusterOverhang/);
+        expect(contentSource).toMatch(/getElementById\('sort-buttons-container'\)/);
+        expect(contentSource).toMatch(/overTop: divRect\.top - top/);
+        expect(contentSource).toMatch(/visTop = top - o\.overTop/);
+    });
+
+    test('sort/edit/set controls snap to the nearest side and vertical edge', () => {
+        // #54 follow-up: they stayed right-aligned regardless of where the
+        // cluster was dragged. Now they snap left/right and above/below.
+        expect(contentSource).toMatch(/function alignSortContainerToCluster/);
+        expect(contentSource).toMatch(/sortC\.style\.left = '0'; sortC\.style\.right = 'auto'/);
+        expect(contentSource).toMatch(/sortC\.style\.right = '0'; sortC\.style\.left = 'auto'/);
+        expect(contentSource).toMatch(/sortC\.style\.top = '100%'; sortC\.style\.bottom = 'auto'/);
+        expect(contentSource).toMatch(/sortC\.style\.bottom = '100%'; sortC\.style\.top = 'auto'/);
+    });
+
+    test('alignment is re-applied live while dragging', () => {
+        expect(contentSource).toMatch(/function onButtonDragMove[\s\S]*?alignSortContainerToCluster\(\);/);
     });
 
     test('resize overrides the max-width cap so the cluster can grow', () => {

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -38,8 +38,15 @@ describe('Free button positioning & resizing (issue #54)', () => {
 
     test('position is clamped into the viewport (on apply and on window resize)', () => {
         expect(contentSource).toMatch(/function clampButtonToViewport/);
-        expect(contentSource).toMatch(/window\.innerWidth - o\.width/);
+        expect(contentSource).toMatch(/viewportW\(\) - o\.width/);
         expect(contentSource).toMatch(/window\.addEventListener\('resize', function\(\) \{\s*if \(freeButtonPosition\) applyFreeButtonPosition\(\);/);
+    });
+
+    test('clamp excludes the scrollbar gutter (documentElement.clientWidth, not innerWidth)', () => {
+        // Right-/bottom-sticking grips were sliding under the scrollbar because
+        // window.innerWidth includes it; clientWidth does not.
+        expect(contentSource).toMatch(/function viewportW\(\) \{ return document\.documentElement\.clientWidth/);
+        expect(contentSource).toMatch(/function viewportH\(\) \{ return document\.documentElement\.clientHeight/);
     });
 
     test('clamp accounts for the overhanging sort/edit/set controls (no top-edge clipping)', () => {
@@ -91,11 +98,16 @@ describe('Free button positioning & resizing (issue #54)', () => {
         expect(contentSource).toMatch(/#custom-extension-wrapper\.menu-open #sort-buttons-container \{[\s\S]*?opacity: 1;[\s\S]*?pointer-events: auto;/);
     });
 
-    test('a gear button is added, hover-revealed, and toggles the menu', () => {
+    test('a gear button is added (always visible) and toggles the menu', () => {
         expect(contentSource).toMatch(/id = 'button-gear'/);
-        // Gear is hidden until hover; visible on wrapper hover or when menu is open.
-        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #button-gear,\s*#custom-extension-wrapper\.menu-open #button-gear \{/);
+        // Gear is always visible for discoverability, brighter on hover/open.
+        expect(contentSource).toMatch(/#button-gear \{[\s\S]*?cursor: pointer;[\s\S]*?opacity: 0\.65;/);
+        expect(contentSource).toMatch(/#button-gear:hover,\s*#custom-extension-wrapper\.menu-open #button-gear \{ opacity: 1; \}/);
         expect(contentSource).toMatch(/gearButton\.addEventListener\('click', function\(e\) \{[\s\S]*?buttonDiv\.classList\.toggle\('menu-open'\)/);
+    });
+
+    test('the grip + gear are grouped to the right, not spread to opposite edges', () => {
+        expect(contentSource).toMatch(/#button-drag-handle \{[\s\S]*?justify-content: flex-end;/);
     });
 
     test('click-away closes the gear menu', () => {

--- a/tests/free-button-layout.test.js
+++ b/tests/free-button-layout.test.js
@@ -98,12 +98,15 @@ describe('Free button positioning & resizing (issue #54)', () => {
         expect(contentSource).toMatch(/#custom-extension-wrapper\.menu-open #sort-buttons-container \{[\s\S]*?opacity: 1;[\s\S]*?pointer-events: auto;/);
     });
 
-    test('a gear button is added (always visible) and toggles the menu', () => {
+    test('a gear button is added and toggles the menu', () => {
         expect(contentSource).toMatch(/id = 'button-gear'/);
-        // Gear is always visible for discoverability, brighter on hover/open.
-        expect(contentSource).toMatch(/#button-gear \{[\s\S]*?cursor: pointer;[\s\S]*?opacity: 0\.65;/);
-        expect(contentSource).toMatch(/#button-gear:hover,\s*#custom-extension-wrapper\.menu-open #button-gear \{ opacity: 1; \}/);
         expect(contentSource).toMatch(/gearButton\.addEventListener\('click', function\(e\) \{[\s\S]*?buttonDiv\.classList\.toggle\('menu-open'\)/);
+    });
+
+    test('grip + gear are hidden until hover, then enlarge and darken', () => {
+        expect(contentSource).toMatch(/#button-move-grip, #button-gear \{[\s\S]*?opacity: 0;/);
+        expect(contentSource).toMatch(/#custom-extension-wrapper:hover #button-move-grip,\s*#custom-extension-wrapper:hover #button-gear,\s*#custom-extension-wrapper\.menu-open #button-gear \{[\s\S]*?opacity: 1;[\s\S]*?transform: scale\(1\.25\);/);
+        expect(contentSource).toMatch(/#button-move-grip:hover,\s*#button-gear:hover \{ color: #000; transform: scale\(1\.4\); \}/);
     });
 
     test('the grip + gear are grouped to the right, not spread to opposite edges', () => {


### PR DESCRIPTION
Closes #54 — forum user konrad_k asked to make the button cluster "freely resizable and movable" beyond the four corner presets.

## What's new
- **Drag to move** — a `☰` grip moves the whole cluster anywhere; position persists (`buttonFreePosition`).
- **Drag to resize** — a corner grip sets the cluster width (and a `min-height` floor); persists (`buttonFreeSize`) and overrides the max-width cap.
- **Gear menu** — the rarely-used sort / edit-layout / set-picker controls now hide behind a `⚙` gear instead of taking permanent space. Click to open, click-away to close.
- **Hover-revealed chrome** — the grip and gear are hidden at rest and reveal (enlarged + darkened, via `transform` so no reflow) on cluster hover.
- **Alt+N** still cycles the corner presets and now doubles as a "reset free layout" escape hatch.

## Robustness
- Position is clamped into the viewport on load and on window resize, using `documentElement.clientWidth/Height` so the right-edge chrome stays clear of the scrollbar gutter.
- Clamp accounts for the overhanging sort/edit/set controls and resize grip so nothing clips off the top edge.
- Sort/edit/set controls snap to the side and vertical edge nearest the cluster (live during drag).
- Resize uses `min-height` (not a hard height) + `align-content: flex-start` so taller content never spills past the box and lands the toolbar mid-buttons.

## Tests
- `tests/free-button-layout.test.js` — 23 source-assertion tests (matching the repo's existing test style).
- Full suite: **309 passing**.
- No manifest/permission changes → no new AMO/CWS review surface.

## Notes
- Iterated several rounds on the UX with the maintainer (visibility, alignment, scrollbar, spill); current state confirmed as looking/feeling good.
- README test count bumped 256 → 309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)